### PR TITLE
2025 Career Data Update

### DIFF
--- a/data-cleaning/meds-placement-cleaning.qmd
+++ b/data-cleaning/meds-placement-cleaning.qmd
@@ -43,6 +43,12 @@ us_names <- c("USA", "US", "Usa")
 # unique(meds_status$member_status)
 
 meds_status_cleaned <- meds_status |> 
+  
+##~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+##            remove individuals who never filled out career survey         ----
+##~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  filter(!member_status == "Sent") |>
 
 ##~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ##                      assign status to broader buckets                    ----

--- a/data-cleaning/mesm-placement-cleaning.qmd
+++ b/data-cleaning/mesm-placement-cleaning.qmd
@@ -60,6 +60,12 @@ international_cities <- c("Ontario", "Tautira", "Michoacan", "Galapagos", "Bonai
 
 ```{r}
 mesm_status_cleaned <- mesm_status |> 
+  
+##~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+##            remove individuals who never filled out career survey         ----
+##~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  filter(!member_status == "Sent") |>
 
 ##~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ##                      assign status to broader buckets                    ----


### PR DESCRIPTION
Changes:
- update years to include 2025
- filter out "Sent" status in active placement dataframes
- remove duplicate students as well as `NA` rows
- edit state and city names in observations that didn't match the convention